### PR TITLE
Shared component markdown-editor: edit/preview height difference fixed.

### DIFF
--- a/src/app/shared/components/markdown-editor/markdown-editor.component.scss
+++ b/src/app/shared/components/markdown-editor/markdown-editor.component.scss
@@ -15,7 +15,8 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 300px;
+    height: 333px;
+
     background-color: var(--mdc-filled-text-field-container-color);
     box-sizing: border-box;
 


### PR DESCRIPTION
Pull request resolves: #36 
Hardcoded height SCSS attribute of .editor-preview class to match the default .editor-form-field class (Laziest solution ever applied).
